### PR TITLE
Allow creating issues without the issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,4 +1,4 @@
-blank_issues_enabled: false
+blank_issues_enabled: true
 contact_links:
   - name: Eterna Forum
     url: https://forum.eternagame.org


### PR DESCRIPTION
Currently, when creating an issue you are required to use one of the issue templates. However, there are some issues that don't fall cleanly into any template, like issues epics or ergonomics-related issues.